### PR TITLE
Update hamcrest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,14 +24,8 @@
   <dependencies>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>1.2.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <version>1.2.1</version>
+      <artifactId>hamcrest</artifactId>
+      <version>2.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
 _🤖 This is an automatic PR for replacing the deprecated 'hamcrest-*' modules with 'hamcrest'._

  All deprecated modules' code has been merged into 'hamcrest'.
  Consumers of `hamcrest-*` should replace the dependency with `hamcrest`, which is the drop-in module containing the code of the deprecated `hamcrest-*` modules.

  Ping `@NotMyFault` if you have questions.

  _[script source](https://github.com/NotMyFault/jenkins-version-updater)_

Edit: The build failure is unrelated to this PR:
> 15:23:09  Caused by: org.apache.maven.plugin.PluginExecutionException: Execution default-enforce of goal org.kohsuke:access-modifier-checker:1.31:enforce failed: Unable to load the mojo 'enforce' in the plugin 'org.kohsuke:access-modifier-checker:1.31' due to an API incompatibility: org.codehaus.plexus.component.repository.exception.ComponentLookupException: org/kohsuke/accmod/impl/EnforcerMojo has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0

ci.jenkins.io builds with maven versions supporting Java 8 onwards only. Once this project updates its dependencies, this PR is good to go.